### PR TITLE
There is a problem with resolving vars like "{user.login}".

### DIFF
--- a/src/main/java/ru/alfabank/alfatest/cucumber/ScopedVariables.java
+++ b/src/main/java/ru/alfabank/alfatest/cucumber/ScopedVariables.java
@@ -56,7 +56,7 @@ public class ScopedVariables {
      * @param textToReplaceIn строка, в которой необходимо выполнить замену (не модифицируется)
      */
     public String replaceVariables(String textToReplaceIn) {
-        Pattern p = Pattern.compile("\\{(\\w+)\\}");
+        Pattern p = Pattern.compile("\\{([^{}]+)\\}");
         Matcher m = p.matcher(textToReplaceIn);
         StringBuffer buffer = new StringBuffer();
         while (m.find()) {

--- a/src/main/java/ru/alfabank/steps/DefaultApiSteps.java
+++ b/src/main/java/ru/alfabank/steps/DefaultApiSteps.java
@@ -167,7 +167,7 @@ public class DefaultApiSteps {
      * @return новая строка
      */
     public static String resolveVars(String inputString) {
-        Pattern p = Pattern.compile("\\{(\\w+)\\}");
+        Pattern p = Pattern.compile("\\{([^{}]+)\\}");
         Matcher m = p.matcher(inputString);
         String newString = "";
         while (m.find()) {

--- a/src/test/java/ru/alfabank/loadPropertyTests/PropertyLoaderTests.java
+++ b/src/test/java/ru/alfabank/loadPropertyTests/PropertyLoaderTests.java
@@ -85,6 +85,19 @@ public class PropertyLoaderTests {
         assertThat("Итоговый URL не равен '//ru/credit/caramba/alfalab/'", actual, Matchers.equalTo("//ru/credit/caramba/alfalab/"));
     }
 
+    @Test
+    public void getValuesByNameWithDot() {
+        String resolvedString = resolveVars("{testUser.password}");
+        assertThat("успешно разрезолвилась переменная с .", resolvedString, Matchers.equalTo("testPassword"));
+    }
+
+    @Test
+    public void getValueFromMapByNameWithDot() {
+        akitaScenario.setVar("user.login", "superLogin");
+        String resolvedString = akitaScenario.replaceVariables("{user.login}");
+        assertThat("успешно разрезолвилась переменная с .", resolvedString, Matchers.equalTo("superLogin"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void getNotExistingValue() {
         resolveVars("{RandomTestVariable3321}");


### PR DESCRIPTION
Поправил регулярки. Теперь можно в Степах использовать переменные с точками и другими символами внутри, такие как "{user.login}"