### PR TITLE
bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,5 +152,6 @@ jacocoTestReport {
 license {
     header rootProject.file('HEADER')
     exclude ("body.json")
+    exclude ("bodyWithParams.json")
     strictCheck false
 }

--- a/src/main/java/ru/alfabank/alfatest/cucumber/ScopedVariables.java
+++ b/src/main/java/ru/alfabank/alfatest/cucumber/ScopedVariables.java
@@ -115,10 +115,11 @@ public class ScopedVariables {
         while (m.find()) {
             String varName = m.group(1);
             String value = loadProperty(varName, (String) AkitaScenario.getInstance().tryGetVar(varName));
-            if (value == null)
-                throw new IllegalArgumentException(
-                    "Значение " + varName +
-                        " не было найдено ни в application.properties, ни в environment переменной");
+            if (value == null) {
+                AkitaScenario.getInstance().write(
+                        "Значение " + varName +
+                                " не было найдено ни в application.properties, ни в environment переменной");
+            }
             newString = m.replaceFirst(value);
             if (isJSONValid(newString)) return newString;
             m = p.matcher(newString);

--- a/src/main/java/ru/alfabank/steps/DefaultApiSteps.java
+++ b/src/main/java/ru/alfabank/steps/DefaultApiSteps.java
@@ -164,8 +164,8 @@ public class DefaultApiSteps {
         String body = null;
         RequestSpecification request = given();
         for (RequestParam requestParam : paramsTable) {
-            String value = resolveJsonVars(requestParam.getValue());
             String name = requestParam.getName();
+            String value = requestParam.getValue();
             switch (requestParam.getType()) {
                 case PARAMETER:
                     request.param(name, value);
@@ -174,7 +174,9 @@ public class DefaultApiSteps {
                     request.header(name, value);
                     break;
                 case BODY:
-                    request.body(loadValueFromFileOrPropertyOrVariableOrDefault(value));
+                    value = loadValueFromFileOrPropertyOrVariableOrDefault(value);
+                    body = resolveJsonVars(value);
+                    request.body(body);
                     break;
                 default:
                     throw new IllegalArgumentException(String.format("Некорректно задан тип %s для параметра запроса %s ", requestParam.getType(), name));

--- a/src/test/java/ru/alfabank/steps/ApiStepsTest.java
+++ b/src/test/java/ru/alfabank/steps/ApiStepsTest.java
@@ -114,6 +114,28 @@ public class ApiStepsTest {
     }
 
     @Test
+    public void sendHttpRequestFromFileWithVarsPost() throws java.lang.Exception {
+        String body = "{\"person\": {\"name\": \"Jack\", \"age\": 35}, \"object\": {\"var1\": 1}}";
+        String bodyFileName = "/src/test/resources/bodyWithParams.json";
+
+        stubFor(post(urlEqualTo("/post/resource"))
+                .withRequestBody(WireMock.equalTo(body))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("TEST_BODY")));
+
+        List<RequestParam> params = Collections.singletonList(
+                RequestParam.builder()
+                        .name("body")
+                        .type(RequestParamType.BODY)
+                        .value(bodyFileName)
+                        .build());
+        api.sendHttpRequestSaveResponse("POST", "/post/resource", "RESPONSE_POST_BODY", params);
+        assertThat(akitaScenario.getVar("RESPONSE_POST_BODY"), equalTo("TEST_BODY"));
+    }
+
+    @Test
     public void sendHttpRequestSaveResponseTest() throws java.lang.Exception {
         stubFor(post(urlEqualTo("/post/saveWithTable"))
             .willReturn(aResponse()

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -34,6 +34,8 @@ bodyValue={"property":"body"}
 var2="2"
 var3=3
 titleFromProperty=Title
+bodyWithParams1=Jack
+bodyWithParams2=35
 
 strJson = {"object1" : { "array" : ["stringInArray", 0.003, true, false, null], "innerObject": {"str": "qwer"} }, "object2": {"number" : 0.003, "string" : "stringValue", "boolean" : true, "nullName" : null}, "object3": {"number": -3579.09}}
 strTemplate = {"name": "_name_", "age": _age_}

--- a/src/test/resources/bodyWithParams.json
+++ b/src/test/resources/bodyWithParams.json
@@ -1,0 +1,1 @@
+{"person": {"name": "{bodyWithParams1}", "age": {bodyWithParams2}}, "object": {"var1": 1}}


### PR DESCRIPTION
Думаю нужно сначала вызвать метод loadValueFromFileOrPropertyOrVariableOrDefault, а потом уже полученный результат передать в метод resolveJsonVars. И актуально это только для BODY.

Нужно учесть, что если телом будет  json формат, то в нём используются фигурные скобки. Например в json'е {"name": "Alex", "object1": {"number" : 0.003}} регулярна будет считать значение "number" : 0.003 переменной. Так как такой переменной нигде не будет, то будет выброшено исключение. Самый простой способ это отказаться от исключения и просто писать это в лог.