### PR TITLE
Fix profile bug

### DIFF
--- a/src/main/java/ru/alfabank/tests/core/helpers/PropertyLoader.java
+++ b/src/main/java/ru/alfabank/tests/core/helpers/PropertyLoader.java
@@ -195,7 +195,7 @@ public class PropertyLoader {
         Properties instance = new Properties();
         String profile = System.getProperty("profile", "");
         if (!Strings.isNullOrEmpty(profile)) {
-            String path = Paths.get(profile, PROPERTIES_FILE).toString();
+            String path = Paths.get(profile).toString();
             URL url = PropertyLoader.class.getClassLoader().getResource(path);
             try (
                 InputStream resourceStream = url.openStream();


### PR DESCRIPTION
Если прописать в переменную profile проперти файл, то в методе PropertyLoader.getProfilePropertiesInstance в строке с Paths.get() к данному файлу конкатенируется константа application.properties и приводит к NullPointerException'у.